### PR TITLE
fix: Upgrade dependencies and migrate from Iterator to Yielder

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -5,7 +5,8 @@ licences = ["MIT"]
 repository = { type = "github", user = "olian04", repo = "gleam-stdin" }
 
 [dependencies]
-gleam_stdlib = ">= 0.38.0 and < 1.0.0"
+gleam_stdlib = ">= 0.39.0 and < 1.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [javascript]
 typescript_declarations = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
+  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.38.0 and < 1.0.0"}
+gleam_stdlib = { version = ">= 0.39.0 and < 1.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }

--- a/src/stdin.gleam
+++ b/src/stdin.gleam
@@ -1,6 +1,6 @@
 import gleam/dynamic
-import gleam/iterator
 import gleam/result
+import gleam/yielder
 
 @external(erlang, "io", "get_line")
 @external(javascript, "./js_ffi.mjs", "read_line")
@@ -18,8 +18,8 @@ fn assert_upwrap(res: Result(a, _)) -> a {
   a
 }
 
-pub fn stdin() -> iterator.Iterator(String) {
-  iterator.repeatedly(read_line)
-  |> iterator.take_while(result.is_ok)
-  |> iterator.map(assert_upwrap)
+pub fn stdin() -> yielder.Yielder(String) {
+  yielder.repeatedly(read_line)
+  |> yielder.take_while(result.is_ok)
+  |> yielder.map(assert_upwrap)
 }

--- a/src/stdin_test.gleam
+++ b/src/stdin_test.gleam
@@ -1,9 +1,9 @@
 import gleam/io
-import gleam/iterator
+import gleam/yielder
 import stdin.{stdin}
 
 pub fn main() {
   stdin()
-  |> iterator.to_list
+  |> yielder.to_list
   |> io.debug
 }


### PR DESCRIPTION
- Update `gleam_stdlib` from 0.38.0 to 0.39.0. This update is because the `yielder` module use `dict.upsert` function, which is added in 0.39.0.
- Add `gleam_yielder` dependency (1.1.0)
- Replace `gleam/iterator` with `gleam/yielder` in `stdin.gleam` and `stdin_test.gleam`
- Update import and function calls to use `Yielder` instead of `Iterator`