### PR TITLE
Update gleam_stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,6 +6,7 @@ repository = { type = "github", user = "olian04", repo = "gleam-stdin" }
 
 [dependencies]
 gleam_stdlib = ">= 0.38.0 and < 1.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [javascript]
 typescript_declarations = true

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "stdin"
-version = "1.1.4"
+version = "2.0.0"
 description = "This package provides a synchronous iterator for consuming stdin. It supports all the non-browser targets, Erlang, Node, Deno, and Bun."
 licences = ["MIT"]
 repository = { type = "github", user = "olian04", repo = "gleam-stdin" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.38.0 and < 1.0.0"}
+gleam_stdlib = { version = ">= 0.38.0 and < 1.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }

--- a/src/stdin.gleam
+++ b/src/stdin.gleam
@@ -1,5 +1,5 @@
 import gleam/dynamic
-import gleam/iterator
+import gleam/yielder
 import gleam/result
 
 @external(erlang, "io", "get_line")
@@ -10,7 +10,7 @@ fn read_line() -> Result(String, Nil) {
   ffi_read_line("")
   |> dynamic.from()
   |> dynamic.string()
-  |> result.nil_error()
+  |> result.replace_error(Nil)
 }
 
 fn assert_upwrap(res: Result(a, _)) -> a {
@@ -18,8 +18,8 @@ fn assert_upwrap(res: Result(a, _)) -> a {
   a
 }
 
-pub fn stdin() -> iterator.Iterator(String) {
-  iterator.repeatedly(read_line)
-  |> iterator.take_while(result.is_ok)
-  |> iterator.map(assert_upwrap)
+pub fn stdin() -> yielder.Yielder(String) {
+  yielder.repeatedly(read_line)
+  |> yielder.take_while(result.is_ok)
+  |> yielder.map(assert_upwrap)
 }

--- a/src/stdin.gleam
+++ b/src/stdin.gleam
@@ -18,6 +18,9 @@ fn assert_upwrap(res: Result(a, _)) -> a {
   a
 }
 
+/// Returns a yielder that yields each line of input from stdin as a step.
+/// Evaluating the next step of this yielder will block until a line of input 
+/// is available from stdin to read.
 pub fn stdin() -> yielder.Yielder(String) {
   yielder.repeatedly(read_line)
   |> yielder.take_while(result.is_ok)

--- a/src/stdin_test.gleam
+++ b/src/stdin_test.gleam
@@ -1,9 +1,9 @@
 import gleam/io
-import gleam/iterator
+import gleam/yielder
 import stdin.{stdin}
 
 pub fn main() {
   stdin()
-  |> iterator.to_list
+  |> yielder.to_list
   |> io.debug
 }


### PR DESCRIPTION
Thanks for the handy package! Gleam recently had a large stdlib refactor, and this package won't compile on the newest version. This PR updates the dependencies (and I added a little documentation while I was at it ;) )

Also, talking of breaking changes for v2, is the stdin_test module meant to be public?

Thanks again!