### PR TITLE
Upgrade `gleam_stdlib` to `0.60.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import stdin
 pub fn main() {
   stdin.read_lines()
   |> yielder.to_list
-  |> io.debug
+  |> echo
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The goal of this package is to provide a uniform way of consuming stdin for all 
 | Platform     | Tested version | Date         |
 |:------------:|:-------------:|:------------:|
 | Windows 10   | 2.0.0         | `2025-01-02` |
-| macOS 15.2   | 2.0.0         | `2025-01-02` |
+| macOS 15.5   | 2.0.2         | `2025-05-22` |
 | Ubuntu 24.04 | 2.0.0         | `2025-01-02` |
 | Fedora 40    | 2.0.0         | `2025-01-02` |
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,7 +5,7 @@ licences = ["MIT"]
 repository = { type = "github", user = "olian04", repo = "gleam-stdin" }
 
 [dependencies]
-gleam_stdlib = ">= 0.39.0 and < 1.0.0"
+gleam_stdlib = ">= 0.50.0 and < 1.0.0"
 gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [javascript]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "stdin"
-version = "2.0.1"
+version = "2.0.2"
 description = "This package provides a synchronous iterator for consuming stdin. It supports all the non-browser targets, Erlang, Node, Deno, and Bun."
 licences = ["MIT"]
 repository = { type = "github", user = "olian04", repo = "gleam-stdin" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,5 +7,5 @@ packages = [
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.39.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 1.0.0" }
 gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
 ]
 

--- a/src/stdin.gleam
+++ b/src/stdin.gleam
@@ -1,4 +1,5 @@
 import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/result
 import gleam/yielder
 
@@ -8,9 +9,8 @@ fn ffi_read_line(prompt: String) -> dynamic.Dynamic
 
 fn read_line() -> Result(String, Nil) {
   ffi_read_line("")
-  |> dynamic.from()
-  |> dynamic.string()
-  |> result.nil_error()
+  |> decode.run(decode.string)
+  |> result.replace_error(Nil)
 }
 
 fn assert_upwrap(res: Result(a, _)) -> a {

--- a/test/stdin_test.gleam
+++ b/test/stdin_test.gleam
@@ -1,9 +1,8 @@
-import gleam/io
 import gleam/yielder
 import stdin
 
 pub fn main() {
   stdin.read_lines()
   |> yielder.to_list
-  |> io.debug
+  |> echo
 }


### PR DESCRIPTION
👋🏻 Hello!

First off, thanks for writing this library, I've found it helpful. I noticed a couple small issues I thought I'd fix an offer a PR for.

#### Here's a summary:

> Fix some deprecations:
> 
> 1. From [0.60.0](https://github.com/gleam-lang/stdlib/blob/main/CHANGELOG.md#v0600---2025-05-13):
> 
>     - The `from` function in the dynamic module has been deprecated.
> 
> 2. From [0.52.0](https://github.com/gleam-lang/stdlib/blob/main/CHANGELOG.md#v0520---2025-01-04):
> 
>     - The deprecated …, `result.nil_error`, … functions have been removed.

### Testing

I've got tests passing locally for all the target runtime on my macos environment, but I'm not sure how to validate other platforms.